### PR TITLE
add basic smartparens

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -33,6 +33,7 @@
   '(
     company
     jupyter
+    smartparens
     ))
 
 (defun jupyter/init-jupyter ()
@@ -71,5 +72,8 @@
 
 (defun jupyter/post-init-company ()
   (spacemacs|add-company-backends :backends company-capf :modes jupyter-repl-mode))
+
+(defun jupyter/post-init-smartparens ()
+  (add-hook 'jupyter-repl-mode-hook 'smartparens-mode))
 
 ;;; packages.el ends here


### PR DESCRIPTION
Using python layer as a guide
Ignoring pre-init-smartparens for now, doubt that it is needed for a repl.
