### PR TITLE
WIP: add ability to toggle repl keybindings

### DIFF
--- a/funcs.el
+++ b/funcs.el
@@ -1,0 +1,45 @@
+;;; funcs.el --- jupyter layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Benedikt Tissot <benedikt.tissot@googlemail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Code:
+;;;; jupter repl minor mode keymap
+(spacemacs/set-leader-keys-for-minor-mode 'use-jupyter-repl-mode
+  "'"  'jupyter-run-repl
+  "cc" 'jupyter-load-file
+  "cC" '(lambda (file) (interactive "f\file: ") (progn (jupyter-load-file file) (jupyter-repl-pop-to-buffer)))
+  "sB" '(lambda () (interactive) (progn (jupyter-eval-buffer (current-buffer)) (jupyter-repl-pop-to-buffer)))
+  "sb" 'jupyter-eval-buffer
+  "sF" '(lambda () (interactive) (progn (jupyter-eval-defun) (jupyter-repl-pop-to-buffer)))
+  "sf" 'jupyter-eval-defun
+  "si" 'jupyter-run-repl
+  "sR" '(lambda () (interactive) (progn (jupyter-eval-line-or-region 'null) (jupyter-repl-pop-to-buffer)))
+  "sr" 'jupyter-eval-line-or-region)
+
+;;;; jupyter repl minor mode
+(defvar use-jupyter-repl-mode nil)
+
+(define-minor-mode use-jupyter-repl-mode
+  "Minor mode that will use a jupyter-repl from package
+emacs-jupyter instead of the default repl.
+Dependancies:
+	emacs-jupyter package
+	Jupyter kernel corresponding to the major-mode language.
+		This needs to be installed on your system."
+  :group 'jupyter-repl
+  ;; :lighter "j-repl"
+  :init-value nil
+  (cond
+   (use-jupyter-repl-mode
+    (add-hook 'after-revert-hook 'use-jupyter-repl-mode nil t))
+   (t
+    (remove-hook 'after-revert-hook 'use-jupyter-repl-mode t))))
+
+;;; funcs.el ends here

--- a/packages.el
+++ b/packages.el
@@ -46,6 +46,7 @@
             "ajc" 'jupyter-connect-repl
             "ajr" 'jupyter-run-repl
             "ajs" 'jupyter-server-list-kernels
+            "ajt" 'use-jupyter-repl-mode
             )
           (spacemacs/set-leader-keys-for-major-mode 'jupyter-repl-mode
             "i" 'jupyter-inspect-at-point


### PR DESCRIPTION
"SPC a j t" will alter major-mode repl related keybindings by
invoking use-jupyter-repl-mode minor-mode. Do again to toggle off.


----

# Explanation
Two reasons to toggle keybindings via a minor-mode:
1) It is easier to implement, as well as for end users to configure. 
2) The stock inferior REPL is still available at any time as a backup option.