### PR TITLE
WIP: override-major-mode-keybindings

### DIFF
--- a/funcs.el
+++ b/funcs.el
@@ -30,6 +30,7 @@ Dependancies:
    (t
     (remove-hook 'after-revert-hook 'use-jupyter-repl-mode t))))
 
+;;;; use-jupyter-repl 
 (defun use-jupyter-repl ()
   "Checks whether a jupyter repl kernel is associated with this buffer.
 If there is, then set repl keybindings to use it. Otherwise, associate the
@@ -38,5 +39,11 @@ buffer with a repl. If no repl is running for the major-mode, ask to start one."
   (if (eq jupyter-current-client nil)
       (call-interactively 'jupyter-repl-associate-buffer)
     (call-interactively 'use-jupyter-repl-mode)))
+
+;;;; use-jupyter-eval-pop
+(defun use-jupyter-eval-pop (func &rest args)
+  (interactive)
+  (call-interactively func 'args)
+  (jupyter-repl-pop-to-buffer))
 
 ;;; funcs.el ends here

--- a/funcs.el
+++ b/funcs.el
@@ -14,6 +14,7 @@
 ;;;; jupyter repl minor mode
 ;; (defvar use-jupyter-repl-mode nil)
 
+;;;###autoload
 (define-minor-mode use-jupyter-repl-mode
   "Minor mode that will use a jupyter-repl from package
 emacs-jupyter instead of the default repl.
@@ -30,7 +31,7 @@ Dependancies:
    (t
     (remove-hook 'after-revert-hook 'use-jupyter-repl-mode t))))
 
-;;;; use-jupyter-repl 
+;;;; use-jupyter-repl
 (defun use-jupyter-repl ()
   "Checks whether a jupyter repl kernel is associated with this buffer.
 If there is, then set repl keybindings to use it. Otherwise, associate the

--- a/funcs.el
+++ b/funcs.el
@@ -10,21 +10,9 @@
 ;;; License: GPLv3
 
 ;;; Code:
-;;;; jupter repl minor mode keymap
-(spacemacs/set-leader-keys-for-minor-mode 'use-jupyter-repl-mode
-  "'"  'jupyter-run-repl
-  "cc" 'jupyter-load-file
-  "cC" '(lambda (file) (interactive "f\file: ") (progn (jupyter-load-file file) (jupyter-repl-pop-to-buffer)))
-  "sB" '(lambda () (interactive) (progn (jupyter-eval-buffer (current-buffer)) (jupyter-repl-pop-to-buffer)))
-  "sb" 'jupyter-eval-buffer
-  "sF" '(lambda () (interactive) (progn (jupyter-eval-defun) (jupyter-repl-pop-to-buffer)))
-  "sf" 'jupyter-eval-defun
-  "si" 'jupyter-run-repl
-  "sR" '(lambda () (interactive) (progn (jupyter-eval-line-or-region 'null) (jupyter-repl-pop-to-buffer)))
-  "sr" 'jupyter-eval-line-or-region)
 
 ;;;; jupyter repl minor mode
-(defvar use-jupyter-repl-mode nil)
+;; (defvar use-jupyter-repl-mode nil)
 
 (define-minor-mode use-jupyter-repl-mode
   "Minor mode that will use a jupyter-repl from package
@@ -34,12 +22,21 @@ Dependancies:
 	Jupyter kernel corresponding to the major-mode language.
 		This needs to be installed on your system."
   :group 'jupyter-repl
-  ;; :lighter "j-repl"
+  :lighter "j-repl"
   :init-value nil
   (cond
    (use-jupyter-repl-mode
     (add-hook 'after-revert-hook 'use-jupyter-repl-mode nil t))
    (t
     (remove-hook 'after-revert-hook 'use-jupyter-repl-mode t))))
+
+(defun use-jupyter-repl ()
+  "Checks whether a jupyter repl kernel is associated with this buffer.
+If there is, then set repl keybindings to use it. Otherwise, associate the
+buffer with a repl. If no repl is running for the major-mode, ask to start one."
+  (interactive)
+  (if (eq jupyter-current-client nil)
+      (call-interactively 'jupyter-repl-associate-buffer)
+    (call-interactively 'use-jupyter-repl-mode)))
 
 ;;; funcs.el ends here

--- a/funcs.el
+++ b/funcs.el
@@ -22,7 +22,7 @@ Dependancies:
 	Jupyter kernel corresponding to the major-mode language.
 		This needs to be installed on your system."
   :group 'jupyter-repl
-  :lighter "j-repl"
+  :lighter "jrepl"
   :init-value nil
   (cond
    (use-jupyter-repl-mode
@@ -37,8 +37,8 @@ If there is, then set repl keybindings to use it. Otherwise, associate the
 buffer with a repl. If no repl is running for the major-mode, ask to start one."
   (interactive)
   (if (eq jupyter-current-client nil)
-      (call-interactively 'jupyter-repl-associate-buffer)
-    (call-interactively 'use-jupyter-repl-mode)))
+      (call-interactively 'jupyter-repl-associate-buffer))
+  (call-interactively 'use-jupyter-repl-mode))
 
 ;;;; use-jupyter-eval-pop
 (defun use-jupyter-eval-pop (func &rest args)

--- a/packages.el
+++ b/packages.el
@@ -64,9 +64,7 @@
             "sf" 'jupyter-eval-defun
             "si" 'jupyter-run-repl
             "sR" '(lambda () (interactive) (use-jupyter-eval-pop 'jupyter-eval-line-or-region))
-            "sr" 'jupyter-eval-line-or-region))
-        :config
-        (progn
+            "sr" 'jupyter-eval-line-or-region)
           (when (eq dotspacemacs-editing-style 'vim)
             (evil-define-key '(insert normal) jupyter-repl-mode-map
               (kbd "C-j") 'jupyter-repl-history-next

--- a/packages.el
+++ b/packages.el
@@ -32,14 +32,18 @@
 (defconst jupyter-packages
   '(
     company
-    jupyter
+    (jupyter :location (recipe :fetcher file :path "~/.spacemacs.d/emacs-jupyter"))
+    ;; (jupyter :location local) 
+    ;; jupyter
     smartparens
+    websocket
+    zmq
     ))
-
 (defun jupyter/init-jupyter ()
   (if (executable-find "jupyter")
       (use-package jupyter
         :defer t
+        :demand t
         :init
         (progn
           (spacemacs/set-leader-keys
@@ -83,5 +87,13 @@
 
 (defun jupyter/post-init-smartparens ()
   (add-hook 'jupyter-repl-mode-hook 'smartparens-mode))
+
+(defun jupyter/init-websocket ()
+  (use-package websocket
+    :defer t))
+
+(defun jupyter/init-zmq ()
+  (use-package zmq
+    :defer t))
 
 ;;; packages.el ends here

--- a/packages.el
+++ b/packages.el
@@ -32,13 +32,16 @@
 (defconst jupyter-packages
   '(
     company
-    (jupyter :location (recipe :fetcher file :path "~/.spacemacs.d/emacs-jupyter"))
+    ;; (jupyter :location (recipe :fetcher file :path "~/.spacemacs.d/emacs-jupyter"))
+    ;; upate may 27, 2023
+    (jupyter :Location (recipe :fetcher github :repo "emacs-jupyter/jupyter"))
     ;; (jupyter :location local) 
     ;; jupyter
     smartparens
     websocket
     zmq
     ))
+
 (defun jupyter/init-jupyter ()
   (if (executable-find "jupyter")
       (use-package jupyter

--- a/packages.el
+++ b/packages.el
@@ -47,8 +47,7 @@
             "ajc" 'jupyter-connect-repl
             "ajr" 'jupyter-run-repl
             "ajs" 'jupyter-server-list-kernels
-            "ajt" 'use-jupyter-repl
-            )
+            "ajt" 'use-jupyter-repl)
           (spacemacs/set-leader-keys-for-major-mode 'jupyter-repl-mode
             "i" 'jupyter-inspect-at-point
             "l" 'jupyter-load-file
@@ -58,13 +57,13 @@
           (spacemacs/set-leader-keys-for-minor-mode 'use-jupyter-repl-mode
             "'"  'jupyter-run-repl
             "cc" 'jupyter-load-file
-            "cC" '(lambda (file) (interactive "f\file: ") (progn (jupyter-load-file file) (jupyter-repl-pop-to-buffer)))
-            "sB" '(lambda () (interactive) (progn (jupyter-eval-buffer (current-buffer)) (jupyter-repl-pop-to-buffer)))
+            "cC" '(lambda () (interactive) (use-jupyter-eval-pop 'jupyter-load-file))
+            "sB" '(lambda () (interactive) (use-jupyter-eval-pop 'jupyter-eval-buffer))
             "sb" 'jupyter-eval-buffer
-            "sF" '(lambda () (interactive) (progn (jupyter-eval-defun) (jupyter-repl-pop-to-buffer)))
+            "sF" '(lambda () (interactive) (use-jupyter-eval-pop 'jupyter-eval-defun))
             "sf" 'jupyter-eval-defun
             "si" 'jupyter-run-repl
-            "sR" '(lambda () (interactive) (progn (jupyter-eval-line-or-region 'null) (jupyter-repl-pop-to-buffer)))
+            "sR" '(lambda () (interactive) (use-jupyter-eval-pop 'jupyter-eval-line-or-region))
             "sr" 'jupyter-eval-line-or-region))
         :config
         (progn

--- a/packages.el
+++ b/packages.el
@@ -33,6 +33,7 @@
   '(
     company
     jupyter
+    smartparens
     ))
 
 (defun jupyter/init-jupyter ()
@@ -46,14 +47,25 @@
             "ajc" 'jupyter-connect-repl
             "ajr" 'jupyter-run-repl
             "ajs" 'jupyter-server-list-kernels
-            "ajt" 'use-jupyter-repl-mode
+            "ajt" 'use-jupyter-repl
             )
           (spacemacs/set-leader-keys-for-major-mode 'jupyter-repl-mode
             "i" 'jupyter-inspect-at-point
             "l" 'jupyter-load-file
             "s" 'jupyter-repl-scratch-buffer
             "I" 'jupyter-repl-interrupt-kernel
-            "R" 'jupyter-repl-restart-kernel))
+            "R" 'jupyter-repl-restart-kernel)
+          (spacemacs/set-leader-keys-for-minor-mode 'use-jupyter-repl-mode
+            "'"  'jupyter-run-repl
+            "cc" 'jupyter-load-file
+            "cC" '(lambda (file) (interactive "f\file: ") (progn (jupyter-load-file file) (jupyter-repl-pop-to-buffer)))
+            "sB" '(lambda () (interactive) (progn (jupyter-eval-buffer (current-buffer)) (jupyter-repl-pop-to-buffer)))
+            "sb" 'jupyter-eval-buffer
+            "sF" '(lambda () (interactive) (progn (jupyter-eval-defun) (jupyter-repl-pop-to-buffer)))
+            "sf" 'jupyter-eval-defun
+            "si" 'jupyter-run-repl
+            "sR" '(lambda () (interactive) (progn (jupyter-eval-line-or-region 'null) (jupyter-repl-pop-to-buffer)))
+            "sr" 'jupyter-eval-line-or-region))
         :config
         (progn
           (when (eq dotspacemacs-editing-style 'vim)
@@ -64,13 +76,15 @@
               (kbd "M-j") 'jupyter-repl-forward-cell
               (kbd "M-k") 'jupyter-repl-backward-cell
               (kbd "C-s") 'jupyter-repl-scratch-buffer
-              (kbd "C-R") 'jupyter-repl-history-next-matching
-              (kbd "C-r") 'jupyter-repl-history-previous-matching))
-          ))
+              (kbd "C-R") 'isearch-forward
+              (kbd "C-r") 'isearch-backward))))
 
     (message "jupyter was not found in your path, jupyter is not loaded")))
 
 (defun jupyter/post-init-company ()
   (spacemacs|add-company-backends :backends company-capf :modes jupyter-repl-mode))
+
+(defun jupyter/post-init-smartparens ()
+  (add-hook 'jupyter-repl-mode-hook 'smartparens-mode))
 
 ;;; packages.el ends here

--- a/packages.el
+++ b/packages.el
@@ -69,7 +69,7 @@
             (evil-define-key '(insert normal) jupyter-repl-mode-map
               (kbd "C-j") 'jupyter-repl-history-next
               (kbd "C-k") 'jupyter-repl-history-previous
-              (kbd "C-l") 'jupyter-repl-clear-cells
+              ;; (kbd "C-l") 'jupyter-repl-clear-cells
               (kbd "M-j") 'jupyter-repl-forward-cell
               (kbd "M-k") 'jupyter-repl-backward-cell
               (kbd "C-s") 'jupyter-repl-scratch-buffer


### PR DESCRIPTION
For any major-mode, provide the option to override spacemacs repl related keybindings so that a jupyter repl is used instead.  
- `SPC a j t` Checks for kernel. Calls `jupyter-repl-associate-buffer` if there is no kernel for the buffer. I think check makes most sense here. 
- If there is no kernel for a language, emacs-jupyter will just give an error.  
- This override can be toggled on/off anytime. 

----

Using spacemacs code as a guide:
- looks like minor-mode keybindings should be in `use-package` `:init`
- no consistent location to define a minor-mode, I saw 3 different places.